### PR TITLE
Use double checked locking

### DIFF
--- a/src/NServiceBus.Serverless/ServerlessEndpoint.cs
+++ b/src/NServiceBus.Serverless/ServerlessEndpoint.cs
@@ -59,6 +59,6 @@
 
         readonly SemaphoreSlim semaphoreLock = new SemaphoreSlim(initialCount: 1, maxCount: 1);
 
-        volatile PipelineInvoker pipeline;
+        PipelineInvoker pipeline;
     }
 }

--- a/src/NServiceBus.Serverless/ServerlessEndpoint.cs
+++ b/src/NServiceBus.Serverless/ServerlessEndpoint.cs
@@ -41,9 +41,9 @@
                     if (pipeline == null)
                     {
                         var configuration = configurationFactory();
-                        pipeline = configuration.PipelineInvoker;
-
                         await Endpoint.Start(configuration.EndpointConfiguration).ConfigureAwait(false);
+
+                        pipeline = configuration.PipelineInvoker;
                     }
                 }
                 finally

--- a/src/NServiceBus.Serverless/ServerlessEndpoint.cs
+++ b/src/NServiceBus.Serverless/ServerlessEndpoint.cs
@@ -33,20 +33,23 @@
         /// </summary>
         public async Task Process(MessageContext message)
         {
-            await semaphoreLock.WaitAsync().ConfigureAwait(false);
-            try
+            if (pipeline == null)
             {
-                if (pipeline == null)
+                await semaphoreLock.WaitAsync().ConfigureAwait(false);
+                try
                 {
-                    var configuration = configurationFactory();
-                    pipeline = configuration.PipelineInvoker;
+                    if (pipeline == null)
+                    {
+                        var configuration = configurationFactory();
+                        pipeline = configuration.PipelineInvoker;
 
-                    await Endpoint.Start(configuration.EndpointConfiguration).ConfigureAwait(false);
+                        await Endpoint.Start(configuration.EndpointConfiguration).ConfigureAwait(false);
+                    }
                 }
-            }
-            finally
-            {
-                semaphoreLock.Release();
+                finally
+                {
+                    semaphoreLock.Release();
+                }
             }
 
             await pipeline.PushMessage(message).ConfigureAwait(false);
@@ -56,6 +59,6 @@
 
         readonly SemaphoreSlim semaphoreLock = new SemaphoreSlim(initialCount: 1, maxCount: 1);
 
-        PipelineInvoker pipeline;
+        volatile PipelineInvoker pipeline;
     }
 }


### PR DESCRIPTION
Proposal from @danielmarbach to avoid unnecessary locks once the endpoint has been initialized.

Given the issues with double checked locking in C#, I'm not sure this is really worth to optimize right now. `Lazy` is tricky to use given that we have to `await` the startup. An interesting alternative could be the Task based singleton described here: http://www.laserbrain.se/2015/11/async-singleton-initialization/

Thoughts @boblangley @danielmarbach ?