### PR TITLE
Switch to simpler return value

### DIFF
--- a/src/NServiceBus.Serverless/ServerlessEndpointConfiguration.cs
+++ b/src/NServiceBus.Serverless/ServerlessEndpointConfiguration.cs
@@ -1,6 +1,5 @@
 ﻿namespace NServiceBus.Serverless
 {
-    using System;
     using Recoverability;
     using Serialization;
     using Transport;
@@ -76,11 +75,7 @@
         /// <summary>
         /// Gives access to the underlying endpoint configuration for advanced configuration options.
         /// </summary>
-        public void AdvancedConfiguration(Action<EndpointConfiguration> advancedConfiguration)
-        {
-            //allow access to the underlying EndpointConfiguration for all sorts of configurations/workarounds
-            advancedConfiguration(EndpointConfiguration);
-        }
+        public EndpointConfiguration AdvancedConfiguration => EndpointConfiguration;
 
         readonly ServerlessRecoverabilityPolicy recoverabilityPolicy = new ServerlessRecoverabilityPolicy();
     }


### PR DESCRIPTION
proposal by @danielmarbach to avoid another level of "callback configuration", making the endpoint configuration available as return value / property instead.

The only downside might be that this feels easier to access the underlying `EndpointConfiguration` and maybe we should hide it better but I think that can be discussed at a later point.