### PR TITLE
Support execution context

### DIFF
--- a/src/NServiceBus.Serverless.Tests/APIApprovals.cs
+++ b/src/NServiceBus.Serverless.Tests/APIApprovals.cs
@@ -10,7 +10,7 @@
         [Test]
         public void Approve()
         {
-            var publicApi = ApiGenerator.GeneratePublicApi(typeof(ServerlessEndpoint).Assembly, excludeAttributes: new[] { "System.Runtime.Versioning.TargetFrameworkAttribute" });
+            var publicApi = ApiGenerator.GeneratePublicApi(typeof(ServerlessEndpoint<>).Assembly, excludeAttributes: new[] { "System.Runtime.Versioning.TargetFrameworkAttribute" });
             Approver.Verify(publicApi);
         }
     }

--- a/src/NServiceBus.Serverless.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Serverless.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -1,10 +1,9 @@
 namespace NServiceBus.Serverless
 {
-    public class ServerlessEndpoint
+    public class ServerlessEndpoint<TExecutionContext>
     {
-        public ServerlessEndpoint(System.Func<NServiceBus.Serverless.ServerlessEndpointConfiguration> configurationFactory) { }
-        public ServerlessEndpoint(NServiceBus.Serverless.ServerlessEndpointConfiguration configuration) { }
-        public System.Threading.Tasks.Task Process(NServiceBus.Transport.MessageContext message) { }
+        public ServerlessEndpoint(System.Func<TExecutionContext, NServiceBus.Serverless.ServerlessEndpointConfiguration> configurationFactory) { }
+        public System.Threading.Tasks.Task Process(NServiceBus.Transport.MessageContext message, TExecutionContext executionContext) { }
     }
     public class ServerlessEndpointConfiguration
     {

--- a/src/NServiceBus.Serverless/ServerlessEndpoint.cs
+++ b/src/NServiceBus.Serverless/ServerlessEndpoint.cs
@@ -8,30 +8,22 @@
     /// <summary>
     /// An NServiceBus endpoint which does not receive messages automatically but only handles messages explicitly passed to it
     /// by the caller.
-    /// Instances of <see cref="ServerlessEndpoint" /> can be cached and are thread-safe.
+    /// Instances of <see cref="ServerlessEndpoint{TExecutionContext}" /> can be cached and are thread-safe.
     /// </summary>
-    public class ServerlessEndpoint
+    public class ServerlessEndpoint<TExecutionContext>
     {
         /// <summary>
         /// Create a new session based on the configuration factory provided.
         /// </summary>
-        public ServerlessEndpoint(Func<ServerlessEndpointConfiguration> configurationFactory)
+        public ServerlessEndpoint(Func<TExecutionContext, ServerlessEndpointConfiguration> configurationFactory)
         {
             this.configurationFactory = configurationFactory;
         }
 
         /// <summary>
-        /// Create a new session based on the configuration provided.
-        /// </summary>
-        public ServerlessEndpoint(ServerlessEndpointConfiguration configuration)
-        {
-            configurationFactory = () => configuration;
-        }
-
-        /// <summary>
         /// Lets the NServiceBus pipeline process this message.
         /// </summary>
-        public async Task Process(MessageContext message)
+        public async Task Process(MessageContext message, TExecutionContext executionContext)
         {
             if (pipeline == null)
             {
@@ -40,7 +32,7 @@
                 {
                     if (pipeline == null)
                     {
-                        var configuration = configurationFactory();
+                        var configuration = configurationFactory(executionContext);
                         await Endpoint.Start(configuration.EndpointConfiguration).ConfigureAwait(false);
 
                         pipeline = configuration.PipelineInvoker;
@@ -55,7 +47,7 @@
             await pipeline.PushMessage(message).ConfigureAwait(false);
         }
 
-        readonly Func<ServerlessEndpointConfiguration> configurationFactory;
+        readonly Func<TExecutionContext, ServerlessEndpointConfiguration> configurationFactory;
 
         readonly SemaphoreSlim semaphoreLock = new SemaphoreSlim(initialCount: 1, maxCount: 1);
 


### PR DESCRIPTION
This PR contains the following changes:

1. Enforce execution context for AWS and Azure Functions required to access information available at run-time only (function name and base path) that are required for the endpoint configuration.
1. Removed `ServerlessEndpoint` constructor that does not take endpoint configuration as a factory. Reasons is both AWS and Azure Functions require the context available at run-time only.