### PR TITLE
Make sure we have fresh headers for each FLR

### DIFF
--- a/src/NServiceBus.Serverless/TransportWrapper/PipelineInvoker.cs
+++ b/src/NServiceBus.Serverless/TransportWrapper/PipelineInvoker.cs
@@ -39,7 +39,14 @@
                 try
                 {
                     processingAttempts++;
-                    await onMessage.Invoke(messageContext).ConfigureAwait(false);
+                    await onMessage.Invoke(new MessageContext(
+                            messageContext.MessageId,
+                            new Dictionary<string, string>(messageContext.Headers),
+                            messageContext.Body,
+                            messageContext.TransportTransaction,
+                            messageContext.ReceiveCancellationTokenSource,
+                            messageContext.Extensions))
+                        .ConfigureAwait(false);
                     return;
                 }
                 catch (Exception exception)


### PR DESCRIPTION
We've had to fix a few transports to make sure header manipulations of the core do not leak into FLR attempts. So we should also make sure the serverless package behaves correctly in that regard as well