### PR TITLE
First step in allowing at least the semaphore wait async to be canceled

### DIFF
--- a/src/NServiceBus.Serverless/ServerlessEndpoint.cs
+++ b/src/NServiceBus.Serverless/ServerlessEndpoint.cs
@@ -27,7 +27,7 @@
         {
             if (pipeline == null)
             {
-                await semaphoreLock.WaitAsync().ConfigureAwait(false);
+                await semaphoreLock.WaitAsync(message.ReceiveCancellationTokenSource.Token).ConfigureAwait(false);
                 try
                 {
                     if (pipeline == null)


### PR DESCRIPTION
MessageContext is designed to allow passing in a cancellation token source. If the environment allows for cancellation like azure functions does it is possible to create a linked token source and pass that to the message context. Then as a first step at least the WaitAsync can be canceled. Further changes can then start building on that assumption and for example, allow to opt-out from the FLR attempts