### PR TITLE
Align PipelineInvoker and endpoint with transport seam

### DIFF
--- a/src/NServiceBus.Serverless.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Serverless.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -5,8 +5,8 @@ namespace NServiceBus.Serverless
     {
         protected ServerlessEndpoint(System.Func<TExecutionContext, TConfiguration> configurationFactory) { }
         protected TConfiguration Configuration { get; }
-        public System.Threading.Tasks.Task Process(NServiceBus.Transport.MessageContext message, TExecutionContext executionContext) { }
-        public System.Threading.Tasks.Task<NServiceBus.Transport.ErrorHandleResult> ProcessFailedMessage(NServiceBus.Transport.MessageContext messageContext, System.Exception exception, int immediateProcessingAttempts, TExecutionContext executionContext) { }
+        public System.Threading.Tasks.Task Process(NServiceBus.Transport.MessageContext messageContext, TExecutionContext executionContext) { }
+        public System.Threading.Tasks.Task<NServiceBus.Transport.ErrorHandleResult> ProcessFailedMessage(NServiceBus.Transport.ErrorContext errorContext, TExecutionContext executionContext) { }
     }
     public abstract class ServerlessEndpointConfiguration
     {

--- a/src/NServiceBus.Serverless/ServerlessEndpoint.cs
+++ b/src/NServiceBus.Serverless/ServerlessEndpoint.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.Serverless
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using Transport;
@@ -30,27 +29,19 @@
         /// <summary>
         /// Lets the NServiceBus pipeline process this message.
         /// </summary>
-        public async Task Process(MessageContext message, TExecutionContext executionContext)
+        public async Task Process(MessageContext messageContext, TExecutionContext executionContext)
         {
-            await InitializeEndpointIfNecessary(executionContext, message.ReceiveCancellationTokenSource.Token).ConfigureAwait(false);
+            await InitializeEndpointIfNecessary(executionContext, messageContext.ReceiveCancellationTokenSource.Token).ConfigureAwait(false);
 
-            await pipeline.PushMessage(message).ConfigureAwait(false);
+            await pipeline.PushMessage(messageContext).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Lets the NServiceBus pipeline process this failed message.
         /// </summary>
-        public async Task<ErrorHandleResult> ProcessFailedMessage(MessageContext messageContext, Exception exception, int immediateProcessingAttempts, TExecutionContext executionContext)
+        public async Task<ErrorHandleResult> ProcessFailedMessage(ErrorContext errorContext, TExecutionContext executionContext)
         {
             await InitializeEndpointIfNecessary(executionContext).ConfigureAwait(false);
-
-            var errorContext = new ErrorContext(
-                exception,
-                new Dictionary<string, string>(messageContext.Headers),
-                messageContext.MessageId,
-                messageContext.Body,
-                new TransportTransaction(),
-                immediateProcessingAttempts);
 
             return await pipeline.PushFailedMessage(errorContext).ConfigureAwait(false);
         }

--- a/src/NServiceBus.Serverless/TransportWrapper/PipelineInvoker.cs
+++ b/src/NServiceBus.Serverless/TransportWrapper/PipelineInvoker.cs
@@ -1,7 +1,6 @@
 ﻿namespace NServiceBus.Serverless
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading.Tasks;
     using Transport;
 
@@ -30,21 +29,14 @@
             return Task.CompletedTask;
         }
 
-        public async Task<ErrorHandleResult> PushFailedMessage(ErrorContext errorContext)
+        public Task<ErrorHandleResult> PushFailedMessage(ErrorContext errorContext)
         {
-            return await onError(errorContext).ConfigureAwait(false);
+            return onError(errorContext);
         }
 
-        public async Task PushMessage(MessageContext messageContext)
+        public Task PushMessage(MessageContext messageContext)
         {
-            await onMessage.Invoke(new MessageContext(
-                    messageContext.MessageId,
-                    new Dictionary<string, string>(messageContext.Headers),
-                    messageContext.Body,
-                    messageContext.TransportTransaction,
-                    messageContext.ReceiveCancellationTokenSource,
-                    messageContext.Extensions))
-                .ConfigureAwait(false);
+            return onMessage.Invoke(messageContext);
         }
 
         Func<MessageContext, Task> onMessage;


### PR DESCRIPTION
This pushes forward the concept that @SeanFeldman and @boblangley started with the changes introduced in #16 

Now the endpoint methods are aligned with the transport seam for consistency reason and no copy is done anymore. It is the responsibility of a downstream when they do in memory retries.