### PR TITLE
Ability to initialize the endpoint forcefully

### DIFF
--- a/src/NServiceBus.Serverless.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Serverless.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -4,7 +4,8 @@ namespace NServiceBus.Serverless
         where TConfiguration : NServiceBus.Serverless.ServerlessEndpointConfiguration
     {
         protected ServerlessEndpoint(System.Func<TExecutionContext, TConfiguration> configurationFactory) { }
-        protected TConfiguration Configuration { get; }
+        protected virtual System.Threading.Tasks.Task Initialize(TConfiguration configuration) { }
+        protected System.Threading.Tasks.Task InitializeEndpointIfNecessary(TExecutionContext executionContext, System.Threading.CancellationToken token = null) { }
         public System.Threading.Tasks.Task Process(NServiceBus.Transport.MessageContext messageContext, TExecutionContext executionContext) { }
         public System.Threading.Tasks.Task<NServiceBus.Transport.ErrorHandleResult> ProcessFailedMessage(NServiceBus.Transport.ErrorContext errorContext, TExecutionContext executionContext) { }
     }

--- a/src/NServiceBus.Serverless/ServerlessEndpoint.cs
+++ b/src/NServiceBus.Serverless/ServerlessEndpoint.cs
@@ -22,11 +22,6 @@
         }
 
         /// <summary>
-        /// Lazy initialized configuration
-        /// </summary>
-        protected TConfiguration Configuration { get; private set; }
-
-        /// <summary>
         /// Lets the NServiceBus pipeline process this message.
         /// </summary>
         public async Task Process(MessageContext messageContext, TExecutionContext executionContext)
@@ -46,7 +41,22 @@
             return await pipeline.PushFailedMessage(errorContext).ConfigureAwait(false);
         }
 
-        async Task InitializeEndpointIfNecessary(TExecutionContext executionContext, CancellationToken token = default)
+        /// <summary>
+        /// Concurrency safe initialization method that allows to get access to the strongly typed configuration.
+        /// </summary>
+        /// <remarks>Will only be called once either when <see cref="Process"/>, <see cref="ProcessFailedMessage"/> or <see cref="InitializeEndpointIfNecessary"/> is called.</remarks>
+        /// <param name="configuration">The fully initialized configuration.</param>
+        protected virtual Task Initialize(TConfiguration configuration)
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Allows to forcefully initialize the endpoint if it hasn't been initialized yet.
+        /// </summary>
+        /// <param name="executionContext">The execution context.</param>
+        /// <param name="token">The cancellation token or default cancellation token.</param>
+        protected async Task InitializeEndpointIfNecessary(TExecutionContext executionContext, CancellationToken token = default)
         {
             if (pipeline == null)
             {
@@ -55,10 +65,11 @@
                 {
                     if (pipeline == null)
                     {
-                        Configuration = configurationFactory(executionContext);
-                        await Endpoint.Start(Configuration.EndpointConfiguration).ConfigureAwait(false);
+                        var configuration = configurationFactory(executionContext);
+                        await Initialize(configuration).ConfigureAwait(false);
+                        await Endpoint.Start(configuration.EndpointConfiguration).ConfigureAwait(false);
 
-                        pipeline = Configuration.PipelineInvoker;
+                        pipeline = configuration.PipelineInvoker;
                     }
                 }
                 finally

--- a/src/NServiceBus.Serverless/ServerlessEndpoint.cs
+++ b/src/NServiceBus.Serverless/ServerlessEndpoint.cs
@@ -42,7 +42,7 @@
         }
 
         /// <summary>
-        /// Concurrency safe initialization method that allows to get access to the strongly typed configuration.
+        /// Thread-safe initialization method that allows to get access to the strongly typed configuration.
         /// </summary>
         /// <remarks>Will only be called once either when <see cref="Process"/>, <see cref="ProcessFailedMessage"/> or <see cref="InitializeEndpointIfNecessary"/> is called.</remarks>
         /// <param name="configuration">The fully initialized configuration.</param>
@@ -56,6 +56,7 @@
         /// </summary>
         /// <param name="executionContext">The execution context.</param>
         /// <param name="token">The cancellation token or default cancellation token.</param>
+        // ReSharper disable once MemberCanBePrivate.Global
         protected async Task InitializeEndpointIfNecessary(TExecutionContext executionContext, CancellationToken token = default)
         {
             if (pipeline == null)


### PR DESCRIPTION
- Ability to initialize the endpoint forcefully
- Additional ability to hook up to the strongly typed configuration at a well-defined point in time that is only called once

By default, if the endpoint hasn't been forcefully initialized it will be initialized by the Process methods. This is required for SQS because we need to be able to create S3 clients that have access to the bucket configuration to download the S3 body before we pass it to the process methods