### PR TITLE
Process and ProcessFailedMessage should be protected

### DIFF
--- a/src/NServiceBus.Serverless.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/NServiceBus.Serverless.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -6,8 +6,8 @@ namespace NServiceBus.Serverless
         protected ServerlessEndpoint(System.Func<TExecutionContext, TConfiguration> configurationFactory) { }
         protected virtual System.Threading.Tasks.Task Initialize(TConfiguration configuration) { }
         protected System.Threading.Tasks.Task InitializeEndpointIfNecessary(TExecutionContext executionContext, System.Threading.CancellationToken token = null) { }
-        public System.Threading.Tasks.Task Process(NServiceBus.Transport.MessageContext messageContext, TExecutionContext executionContext) { }
-        public System.Threading.Tasks.Task<NServiceBus.Transport.ErrorHandleResult> ProcessFailedMessage(NServiceBus.Transport.ErrorContext errorContext, TExecutionContext executionContext) { }
+        protected System.Threading.Tasks.Task Process(NServiceBus.Transport.MessageContext messageContext, TExecutionContext executionContext) { }
+        protected System.Threading.Tasks.Task<NServiceBus.Transport.ErrorHandleResult> ProcessFailedMessage(NServiceBus.Transport.ErrorContext errorContext, TExecutionContext executionContext) { }
     }
     public abstract class ServerlessEndpointConfiguration
     {

--- a/src/NServiceBus.Serverless/ServerlessEndpoint.cs
+++ b/src/NServiceBus.Serverless/ServerlessEndpoint.cs
@@ -24,7 +24,7 @@
         /// <summary>
         /// Lets the NServiceBus pipeline process this message.
         /// </summary>
-        public async Task Process(MessageContext messageContext, TExecutionContext executionContext)
+        protected async Task Process(MessageContext messageContext, TExecutionContext executionContext)
         {
             await InitializeEndpointIfNecessary(executionContext, messageContext.ReceiveCancellationTokenSource.Token).ConfigureAwait(false);
 
@@ -34,7 +34,7 @@
         /// <summary>
         /// Lets the NServiceBus pipeline process this failed message.
         /// </summary>
-        public async Task<ErrorHandleResult> ProcessFailedMessage(ErrorContext errorContext, TExecutionContext executionContext)
+        protected async Task<ErrorHandleResult> ProcessFailedMessage(ErrorContext errorContext, TExecutionContext executionContext)
         {
             await InitializeEndpointIfNecessary(executionContext).ConfigureAwait(false);
 


### PR DESCRIPTION
Given the current design enforces inheritance it makes sense to hide the process methods from the public API surface. Customers calling `endpoint.` should only see the concrete downstream process method